### PR TITLE
[BUGFIX] prevent PHP Warning

### DIFF
--- a/Classes/Domain/Model/Logentry.php
+++ b/Classes/Domain/Model/Logentry.php
@@ -42,7 +42,7 @@ class Logentry extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 
     /**
      *  Address
-     * @var Address
+     * @var \AFM\Registeraddress\Domain\Model\Address
      */
     protected $address;
 
@@ -131,7 +131,7 @@ class Logentry extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     }
 
     /**
-     * @param Address
+     * @param \AFM\Registeraddress\Domain\Model\Address
      */
     public function setAddress(Address $address)
     {


### PR DESCRIPTION
Prevent PHP Warning: class_parents(): Class Address does not exist and could not be loaded